### PR TITLE
Fixup `MermaidOutputBinding`

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,12 +2,11 @@ from shiny import App, ui
 from mermaid_module import mermaid_diagram_ui, mermaid_diagram_server
 
 
-app_ui = ui.page_navbar(  
-    ui.nav_panel("A", mermaid_diagram_ui("diagramA")),  
-    ui.nav_panel("B", mermaid_diagram_ui("diagramB")),  
-    ui.nav_panel("C", mermaid_diagram_ui("diagramC")),  
-    title="Mermaid Test App",  
-    id="page",  
+app_ui = ui.page_fixed(  
+    mermaid_diagram_ui("diagramA"),  
+    mermaid_diagram_ui("diagramB"),
+    mermaid_diagram_ui("diagramC"),
+    title="Mermaid Test App"
 )  
 
 

--- a/mermaid/mermaidComponent.js
+++ b/mermaid/mermaidComponent.js
@@ -1,6 +1,11 @@
 import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
 mermaid.startOnLoad = true;
 
+async function drawDiagram(mermaidText) {
+  const {svg} = await mermaid.render('mermaidText', mermaidText.diagram);
+  return svg
+}
+
 class MermaidOutputBinding extends Shiny.OutputBinding {
   find(scope) {
     return scope.find(".shiny-mermaid-output");
@@ -10,15 +15,9 @@ class MermaidOutputBinding extends Shiny.OutputBinding {
 
     // the payload is mermaid text
     const warhead = payload;
-
-
-    const drawDiagram = async function(mermaidText) {
-      const {svg} = await mermaid.render('mermaidText', mermaidText.diagram);
-      // el.innerHTML = svg
-      return svg
-    }
-
+  
     const svg = await drawDiagram(warhead);
+    
     // Why doesn't this work??
     // el.innerHTML = svg;
     setTimeout(() => el.innerHTML = svg, 0)

--- a/mermaid/mermaidComponent.js
+++ b/mermaid/mermaidComponent.js
@@ -14,10 +14,14 @@ class MermaidOutputBinding extends Shiny.OutputBinding {
 
     const drawDiagram = async function(mermaidText) {
       const {svg} = await mermaid.render('mermaidText', mermaidText.diagram);
-      el.innerHTML = svg
+      // el.innerHTML = svg
+      return svg
     }
 
-    await drawDiagram(warhead);
+    const svg = await drawDiagram(warhead);
+    // Why doesn't this work??
+    // el.innerHTML = svg;
+    setTimeout(() => el.innerHTML = svg, 0)
   }
 }
 

--- a/mermaid/mermaidComponent.js
+++ b/mermaid/mermaidComponent.js
@@ -1,4 +1,5 @@
 import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+mermaid.startOnLoad = true;
 
 class MermaidOutputBinding extends Shiny.OutputBinding {
   find(scope) {
@@ -10,9 +11,6 @@ class MermaidOutputBinding extends Shiny.OutputBinding {
     // the payload is mermaid text
     const warhead = payload;
 
-    mermaid.initialize({
-      startOnLoad: false,
-    })
 
     const drawDiagram = async function(mermaidText) {
       const {svg} = await mermaid.render('mermaidText', mermaidText.diagram);

--- a/mermaid/mermaidComponent.js
+++ b/mermaid/mermaidComponent.js
@@ -1,12 +1,14 @@
 import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
 
-let config = { startOnLoad: true, flowchart: { useMaxWidth: false, htmlLabels: true } };
-mermaid.initialize(config);
+let config = { 
+  startOnLoad: true,
+  flowchart: { 
+    useMaxWidth: false,
+    htmlLabels: true 
+  } 
+};
 
-async function drawDiagram(mermaidText) {
-  const {svg} = await mermaid.render('mermaidText', mermaidText.diagram);
-  return svg
-}
+mermaid.initialize(config);
 
 class MermaidOutputBinding extends Shiny.OutputBinding {
   find(scope) {
@@ -14,15 +16,8 @@ class MermaidOutputBinding extends Shiny.OutputBinding {
   }
 
   async renderValue(el, payload) {
-
-    // the payload is mermaid text
-    const warhead = payload;
-  
-    const svg = await drawDiagram(warhead);
-
-    // Why doesn't this work??
-    // el.innerHTML = svg;
-    setTimeout(() => el.innerHTML = svg, 0)
+    const {svg} = await mermaid.render(el.id + "_svg", payload.diagram)
+    el.innerHTML = svg;
   }
 }
 

--- a/mermaid/mermaidComponent.js
+++ b/mermaid/mermaidComponent.js
@@ -1,5 +1,7 @@
 import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
-mermaid.startOnLoad = true;
+
+let config = { startOnLoad: true, flowchart: { useMaxWidth: false, htmlLabels: true } };
+mermaid.initialize(config);
 
 async function drawDiagram(mermaidText) {
   const {svg} = await mermaid.render('mermaidText', mermaidText.diagram);
@@ -17,7 +19,7 @@ class MermaidOutputBinding extends Shiny.OutputBinding {
     const warhead = payload;
   
     const svg = await drawDiagram(warhead);
-    
+
     // Why doesn't this work??
     // el.innerHTML = svg;
     setTimeout(() => el.innerHTML = svg, 0)

--- a/mermaid/mermaidComponent.js
+++ b/mermaid/mermaidComponent.js
@@ -16,7 +16,7 @@ class MermaidOutputBinding extends Shiny.OutputBinding {
   }
 
   async renderValue(el, payload) {
-    const {svg} = await mermaid.render(el.id + "_svg", payload.diagram)
+    const { svg } = await mermaid.render(el.id + "_svg", payload.diagram)
     el.innerHTML = svg;
   }
 }

--- a/mermaid_module.py
+++ b/mermaid_module.py
@@ -20,7 +20,7 @@ class render_mermaid(Renderer[str]):
     """
 
     def auto_output_ui(self) -> Any:
-        return ui.output_mermaid
+        return ui.output_mermaid(self.output_name)
 
     async def transform(self, value: str) -> Jsonifiable:
         return {

--- a/mermaid_module.py
+++ b/mermaid_module.py
@@ -20,7 +20,7 @@ class render_mermaid(Renderer[str]):
     """
 
     def auto_output_ui(self) -> Any:
-        return ui.output_mermaid(self.output_name)
+        return output_mermaid(self.output_id)
 
     async def transform(self, value: str) -> Jsonifiable:
         return {


### PR DESCRIPTION
Fixes the output binding so that each SVG is given its own ID, rather than sharing the same `mermaidText` ID.

I noticed that this component doesn't quite work with Shiny Express, but it's at a good start.